### PR TITLE
Fixed download link and qualification display order

### DIFF
--- a/app/views/includes/qualifications/_induction-others.html
+++ b/app/views/includes/qualifications/_induction-others.html
@@ -17,7 +17,7 @@
         text: "Start date"
       },
       value: {
-        text: "5 June 2015"
+        text: "1 September 2015"
       }
     },
     {
@@ -25,7 +25,7 @@
         text: "End date"
       },
       value: {
-        html: "1 October 2015"
+        html: "19 July 2016"
       }
     },
     {
@@ -33,7 +33,7 @@
         text: "Terms"
       },
       value: {
-        html: "1"
+        html: "3"
       }
     }
   ]
@@ -55,7 +55,7 @@
         text: "Start date"
       },
       value: {
-        text: "5 January 2014"
+        text: "10 September 2014"
       }
     },
     {
@@ -63,7 +63,7 @@
         text: "End date"
       },
       value: {
-        html: "1 June 2015"
+        html: "12 July 2015"
       }
     },
     {
@@ -71,7 +71,7 @@
         text: "Terms"
       },
       value: {
-        html: "2"
+        html: "3"
       }
     }
   ]
@@ -91,36 +91,36 @@
           Status
         </dt>
         <dd class="govuk-summary-list__value">
-          Not Yet Completed 
+          Not Yet Completed
         </dd>
       </div>
- 
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Eligible for one year induction	
+          Eligible for one year induction
         </dt>
         <dd class="govuk-summary-list__value">
            Yes
         </dd>
-  
+
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Extension period 	
+          Extension period
         </dt>
         <dd class="govuk-summary-list__value">
            2 days
         </dd>
-  
-      </div>      
-  
-      
+
+      </div>
+
+
     </dl>
     <div class="induction-history">
       {{ govukDetails({
         summaryText: "Induction history",
         html: detailsTable
-      }) }}  
+      }) }}
     </div>
   </div>
 </div>
@@ -144,47 +144,47 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Exemption reason	
+          Exemption reason
         </dt>
         <dd class="govuk-summary-list__value">
            Extended on appeal
         </dd>
-  
+
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Eligible for one year induction	
+          Eligible for one year induction
         </dt>
         <dd class="govuk-summary-list__value">
            Yes
         </dd>
-  
+
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Extension period 	
+          Extension period
         </dt>
         <dd class="govuk-summary-list__value">
            2 days
         </dd>
-  
-      </div>      
+
+      </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Completed	
+          Completed
         </dt>
         <dd class="govuk-summary-list__value">
             1 November 2015
         </dd>
-  
+
       </div>
-      
+
     </dl>
     <div class="induction-history">
       {{ govukDetails({
         summaryText: "Induction history",
         html: detailsTable
-      }) }}  
+      }) }}
     </div>
   </div>
 </div>
@@ -207,25 +207,25 @@
           Fail
         </dd>
       </div>
- 
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Eligible for one year induction	
+          Eligible for one year induction
         </dt>
         <dd class="govuk-summary-list__value">
            Yes
         </dd>
-  
+
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Extension period 	
+          Extension period
         </dt>
         <dd class="govuk-summary-list__value">
            2 days
         </dd>
-  
-      </div>      
+
+      </div>
 
 
     </dl>

--- a/app/views/includes/qualifications/_induction.html
+++ b/app/views/includes/qualifications/_induction.html
@@ -17,7 +17,7 @@
         text: "Start date"
       },
       value: {
-        text: "5 June 2015"
+        text: "1 September 2015"
       }
     },
     {
@@ -25,7 +25,7 @@
         text: "End date"
       },
       value: {
-        html: "1 October 2015"
+        html: "19 July 2016"
       }
     },
     {
@@ -33,7 +33,7 @@
         text: "Terms"
       },
       value: {
-        html: "1"
+        html: "3"
       }
     }
   ]
@@ -55,7 +55,7 @@
         text: "Start date"
       },
       value: {
-        text: "5 January 2014"
+        text: "10 September 2014"
       }
     },
     {
@@ -63,7 +63,7 @@
         text: "End date"
       },
       value: {
-        html: "1 June 2015"
+        html: "12 July 2015"
       }
     },
     {
@@ -71,7 +71,7 @@
         text: "Terms"
       },
       value: {
-        html: "2"
+        html: "3"
       }
     }
   ]
@@ -94,19 +94,19 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Completed	
+          Completed
         </dt>
         <dd class="govuk-summary-list__value">
-            1 November 2015
+            19 July 2016
         </dd>
-  
+
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Certificate
         </dt>
         <dd class="govuk-summary-list__value">
-          <a download href='#'>Download Induction certificate</a>
+          <a download href='/public/images/Induction certificate.pdf'>Download Induction certificate</a>
         </dd>
       </div>
     </dl>
@@ -114,7 +114,7 @@
       {{ govukDetails({
         summaryText: "Induction history",
         html: detailsTable
-      }) }}  
+      }) }}
     </div>
   </div>
 </div>

--- a/app/views/includes/qualifications/_mq.html
+++ b/app/views/includes/qualifications/_mq.html
@@ -11,7 +11,7 @@
         text: "Awarded"
       },
       value: {
-        text: "30 September 2015"
+        text: "30 September 2018"
       }
     },
     {
@@ -24,4 +24,3 @@
     }
   ]
 }) }}
-

--- a/app/views/landing-pages/v3/qualifications.html
+++ b/app/views/landing-pages/v3/qualifications.html
@@ -28,22 +28,22 @@
       {% include 'includes/qualifications/_npq-executive.html' %}
       <!-- npw headteacher -->
       {% include 'includes/qualifications/_npq-headteacher.html' %}
+      <!-- MQ -->
+      {% include 'includes/qualifications/_mq.html' %}
       <!-- Early years -->
       {% include 'includes/qualifications/_eyts.html' %}
       <!-- Induction -->
       {% include 'includes/qualifications/_induction.html' %}
-      <!-- MQ -->
-      {% include 'includes/qualifications/_mq.html' %}
       <!-- QTS -->
       {% include 'includes/qualifications/_qts.html' %}
       <!-- ITT -->
       {% include 'includes/qualifications/_itt.html' %}
 
      {% elseif data['mvp'] == 'true' or data['mvp'] != 'true' %}
-      <!-- Induction -->
-      {% include 'includes/qualifications/_induction.html' %}
       <!-- MQ -->
       {% include 'includes/qualifications/_mq.html' %}
+      <!-- Induction -->
+      {% include 'includes/qualifications/_induction.html' %}
       <!-- QTS -->
       {% include 'includes/qualifications/_qts.html' %}
       <!-- ITT -->


### PR DESCRIPTION
I have:

* fixed the broken link so that the induction certificate can be downloaded
* changed the order of qualifications so that induction appears in the right place - I also changed some dates so that this makes sense

The qualifications may not be reordered in all circumstances, because there are two routes into the prototype:

* direct
* through the DfE identity prototype 

I'll make further changes in a further pull request so that the qualifications are reordered in all circumstances. These changes are being made now to allow the use of the prototype in a research session.